### PR TITLE
 Fix Rollup build failure in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,26 +58,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Check for .nvmrc file
-        id: check-nvmrc
-        run: |
-          if [ -f .nvmrc ]; then
-            echo "nvmrc_exists=true" >> $GITHUB_OUTPUT
-          else
-            echo "nvmrc_exists=false" >> $GITHUB_OUTPUT
-          fi
-
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
-          cache: "npm"
-          cache-dependency-path: "package-lock.json"
 
-      - name: Install dependencies
+      - name: Clean install dependencies
         run: |
           echo "📦 Installing JavaScript dependencies..."
-          npm ci
+          rm -rf node_modules package-lock.json
+          npm install
           echo "✅ Dependencies installed successfully"
 
       - name: Build JavaScript bundles


### PR DESCRIPTION
## Description
Fixes the `Cannot find module @rollup/rollup-linux-x64-gnu` error that was [causing the JavaScript build to fail](https://github.com/WAVE-Lab-Williams/wave-client/actions/runs/20836570003/job/59862367985).

### Changes
- Removed npm cache configuration that conflicted with clean install
- Removed unused `.nvmrc` file check

The clean install approach (`rm -rf node_modules package-lock.json && npm install`) requires no caching to work properly with Rollup's optional dependencies.