### PR TITLE
Add experiment config support to the client library (`v1.2.0`)

### DIFF
--- a/javascript/src/wave-client.js
+++ b/javascript/src/wave-client.js
@@ -70,7 +70,7 @@ export default class WaveClient {
         this.maxDelay = options.maxDelay || 30000;
 
         // Client version for compatibility checking
-        this.clientVersion = '1.0.0';
+        this.clientVersion = '1.2.0';
 
         // Validate API key is present
         if (!this.apiKey) {
@@ -124,6 +124,28 @@ export default class WaveClient {
      */
     async getVersion() {
         return await this._makeRequest('GET', '/version');
+    }
+
+    /**
+     * Fetch an experiment's runtime config (free-form hyperparameters).
+     *
+     * Readable with an experimentee-level key, so a browser experiment can pull
+     * its own tunable parameters at startup and merge them over in-code defaults.
+     * Returns the narrow config payload only (never the full experiment record).
+     *
+     * @param {string} experimentId - Experiment UUID
+     * @returns {Promise<{experiment_uuid: string, config: Object}>} Config payload
+     *   (`config` is `{}` when none has been set).
+     *
+     * @example
+     * const { config } = await client.getExperimentConfig(experimentId);
+     * const resolved = { ...DEFAULTS, ...config };
+     */
+    async getExperimentConfig(experimentId) {
+        if (!experimentId) {
+            throw new ValidationError('experimentId is required');
+        }
+        return await this._makeRequest('GET', `/api/v1/experiments/${experimentId}/config`);
     }
 
     /**

--- a/javascript/tests/small/constructor.test.js
+++ b/javascript/tests/small/constructor.test.js
@@ -38,7 +38,7 @@ describe('WaveClient Constructor', () => {
         expect(customClient.maxRetries).toBe(3);
         expect(customClient.baseDelay).toBe(2000);
         expect(customClient.maxDelay).toBe(60000);
-        expect(customClient.clientVersion).toBe('1.0.0');
+        expect(customClient.clientVersion).toBe('1.2.0');
     });
 
     test('should use default configuration when options not provided', () => {

--- a/javascript/tests/small/experiment-config.test.js
+++ b/javascript/tests/small/experiment-config.test.js
@@ -1,0 +1,63 @@
+/**
+ * Experiment config tests for WAVE JavaScript client
+ */
+
+import WaveClient, { ValidationError, NotFoundError } from '../../src/wave-client.js';
+import { MOCK_DATA, createMockFetch } from '../test-config.js';
+import { TestSetup } from '../test-utils.js';
+
+describe('WaveClient getExperimentConfig', () => {
+    let client;
+
+    beforeAll(() => {
+        TestSetup.setupGlobalMocks();
+    });
+
+    afterAll(() => {
+        TestSetup.teardownGlobalMocks();
+    });
+
+    beforeEach(() => {
+        TestSetup.clearMocks();
+        client = TestSetup.createTestClient();
+    });
+
+    test('should GET the experiment config endpoint and return the payload', async () => {
+        const payload = {
+            experiment_uuid: MOCK_DATA.experimentId,
+            config: { number_of_repetitions: 2 }
+        };
+        fetch.mockImplementation(createMockFetch(payload));
+
+        const result = await client.getExperimentConfig(MOCK_DATA.experimentId);
+
+        expect(result).toEqual(payload);
+        expect(fetch).toHaveBeenCalledWith(
+            `http://localhost:8000/api/v1/experiments/${MOCK_DATA.experimentId}/config`,
+            expect.objectContaining({ method: 'GET' })
+        );
+    });
+
+    test('should return an empty config object when none is set', async () => {
+        const payload = { experiment_uuid: MOCK_DATA.experimentId, config: {} };
+        fetch.mockImplementation(createMockFetch(payload));
+
+        const result = await client.getExperimentConfig(MOCK_DATA.experimentId);
+        expect(result.config).toEqual({});
+    });
+
+    test('should require an experimentId', async () => {
+        await expect(client.getExperimentConfig()).rejects.toThrow(ValidationError);
+        await expect(client.getExperimentConfig('')).rejects.toThrow('experimentId is required');
+        await expect(client.getExperimentConfig(null)).rejects.toThrow(ValidationError);
+    });
+
+    test('should surface 404 for an unknown experiment', async () => {
+        fetch.mockImplementation(
+            createMockFetch(MOCK_DATA.errorResponses.notFound, { status: 404, ok: false })
+        );
+        await expect(client.getExperimentConfig(MOCK_DATA.experimentId)).rejects.toThrow(
+            NotFoundError
+        );
+    });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wave-client-js",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "JavaScript client for the WAVE Backend API",
   "main": "javascript/dist/wave-client.umd.js",
   "module": "javascript/dist/wave-client.esm.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wave-client"
-version = "1.1.0"
+version = "1.2.0"
 description = "Dual-language client library (JavaScript + Python) for the WAVE Backend API"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/python/tests/small/test_experiments.py
+++ b/python/tests/small/test_experiments.py
@@ -1,0 +1,87 @@
+"""Unit tests for the experiments resource — config support."""
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_create_passes_config(wave_client, sample_experiment):
+    """create() forwards `config` in the POST body."""
+    wave_client._http_client.request.return_value = sample_experiment
+
+    await wave_client.experiments.create(
+        experiment_type_id=1,
+        description="with config",
+        config={"number_of_repetitions": 3},
+    )
+
+    method, url, json_data, _params = wave_client._http_client.request.await_args.args
+    assert method == "POST"
+    assert url == "/api/v1/experiments/"
+    assert json_data["config"] == {"number_of_repetitions": 3}
+
+
+@pytest.mark.asyncio
+async def test_create_defaults_config_to_empty(wave_client, sample_experiment):
+    """Omitting config sends an empty object (not null)."""
+    wave_client._http_client.request.return_value = sample_experiment
+
+    await wave_client.experiments.create(experiment_type_id=1, description="no config")
+
+    _method, _url, json_data, _params = wave_client._http_client.request.await_args.args
+    assert json_data["config"] == {}
+
+
+@pytest.mark.asyncio
+async def test_update_includes_config_when_provided(wave_client, sample_experiment):
+    """update() includes config when set; exclude_none drops it when not."""
+    wave_client._http_client.request.return_value = sample_experiment
+
+    await wave_client.experiments.update(
+        "550e8400-e29b-41d4-a716-446655440000", config={"number_of_repetitions": 5}
+    )
+    _m, _u, json_data, _p = wave_client._http_client.request.await_args.args
+    assert json_data["config"] == {"number_of_repetitions": 5}
+
+
+@pytest.mark.asyncio
+async def test_update_omits_config_when_none(wave_client, sample_experiment):
+    """update() with no config must not send a null config (exclude_none)."""
+    wave_client._http_client.request.return_value = sample_experiment
+
+    await wave_client.experiments.update(
+        "550e8400-e29b-41d4-a716-446655440000", description="just a description"
+    )
+    _m, _u, json_data, _p = wave_client._http_client.request.await_args.args
+    assert "config" not in json_data
+
+
+@pytest.mark.asyncio
+async def test_get_config_hits_config_endpoint(wave_client):
+    """get_config() issues a GET to the narrow config endpoint."""
+    uuid = "550e8400-e29b-41d4-a716-446655440000"
+    wave_client._http_client.request.return_value = {
+        "experiment_uuid": uuid,
+        "config": {"number_of_repetitions": 2},
+    }
+
+    result = await wave_client.experiments.get_config(uuid)
+
+    method, url, _json, _params = wave_client._http_client.request.await_args.args
+    assert method == "GET"
+    assert url == f"/api/v1/experiments/{uuid}/config"
+    assert result["config"] == {"number_of_repetitions": 2}
+
+
+@pytest.mark.asyncio
+async def test_set_config_puts_wrapped_body(wave_client):
+    """set_config() PUTs a {"config": ...} body to the config endpoint."""
+    uuid = "550e8400-e29b-41d4-a716-446655440000"
+    config = {"number_of_repetitions": 4}
+    wave_client._http_client.request.return_value = {"experiment_uuid": uuid, "config": config}
+
+    await wave_client.experiments.set_config(uuid, config)
+
+    method, url, json_data, _params = wave_client._http_client.request.await_args.args
+    assert method == "PUT"
+    assert url == f"/api/v1/experiments/{uuid}/config"
+    assert json_data == {"config": config}

--- a/python/wave_client/models/base.py
+++ b/python/wave_client/models/base.py
@@ -96,6 +96,9 @@ class ExperimentCreate(BaseModel):
     description: str = Field(..., description="Experiment description")
     tags: List[str] = Field(default_factory=list, max_length=10, description="Tags (max 10)")
     additional_data: Dict[str, Any] = Field(default_factory=dict, description="Additional metadata")
+    config: Dict[str, Any] = Field(
+        default_factory=dict, description="Experiment hyperparameters (free-form)"
+    )
 
 
 class ExperimentUpdate(BaseModel):
@@ -104,6 +107,9 @@ class ExperimentUpdate(BaseModel):
     description: Optional[str] = Field(None, description="Experiment description")
     tags: Optional[List[str]] = Field(None, max_length=10, description="Tags (max 10)")
     additional_data: Optional[Dict[str, Any]] = Field(None, description="Additional metadata")
+    config: Optional[Dict[str, Any]] = Field(
+        None, description="Experiment hyperparameters (free-form); replaces stored config"
+    )
 
 
 class Experiment(BaseModel):
@@ -116,6 +122,7 @@ class Experiment(BaseModel):
     description: str
     tags: List[str] = Field(default_factory=list)
     additional_data: Dict[str, Any] = Field(default_factory=dict)
+    config: Dict[str, Any] = Field(default_factory=dict)
     created_at: datetime
     updated_at: datetime
     experiment_type: ExperimentType  # Nested model

--- a/python/wave_client/resources/experiments.py
+++ b/python/wave_client/resources/experiments.py
@@ -16,6 +16,7 @@ class ExperimentsResource(BaseResource):
         description: str,
         tags: Optional[List[str]] = None,
         additional_data: Optional[Dict[str, Any]] = None,
+        config: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """Create a new experiment.
 
@@ -24,6 +25,7 @@ class ExperimentsResource(BaseResource):
             description: Experiment description.
             tags: List of tags (max 10).
             additional_data: Additional metadata.
+            config: Experiment hyperparameters (free-form) the frontend pulls at runtime.
 
         Returns:
             Created experiment response.
@@ -34,6 +36,7 @@ class ExperimentsResource(BaseResource):
             description=description,
             tags=tags or [],
             additional_data=additional_data or {},
+            config=config or {},
         )
 
         return await self._request(
@@ -92,6 +95,7 @@ class ExperimentsResource(BaseResource):
         description: Optional[str] = None,
         tags: Optional[List[str]] = None,
         additional_data: Optional[Dict[str, Any]] = None,
+        config: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """Update experiment.
 
@@ -100,6 +104,7 @@ class ExperimentsResource(BaseResource):
             description: Experiment description.
             tags: List of tags (max 10).
             additional_data: Additional metadata.
+            config: Experiment hyperparameters (free-form); replaces stored config.
 
         Returns:
             Updated experiment response.
@@ -109,12 +114,40 @@ class ExperimentsResource(BaseResource):
             description=description,
             tags=tags,
             additional_data=additional_data,
+            config=config,
         )
 
         return await self._request(
             "PUT",
             f"/api/v1/experiments/{experiment_uuid}",
             json_data=validated_data.model_dump(exclude_none=True),
+        )
+
+    async def get_config(self, experiment_uuid: str) -> Dict[str, Any]:
+        """Get an experiment's runtime config (hyperparameters).
+
+        Args:
+            experiment_uuid: Experiment UUID.
+
+        Returns:
+            Narrow config payload: ``{"experiment_uuid": ..., "config": {...}}``.
+        """
+        return await self._request("GET", f"/api/v1/experiments/{experiment_uuid}/config")
+
+    async def set_config(self, experiment_uuid: str, config: Dict[str, Any]) -> Dict[str, Any]:
+        """Replace an experiment's runtime config (requires RESEARCHER role).
+
+        Args:
+            experiment_uuid: Experiment UUID.
+            config: Free-form hyperparameters; replaces the stored config entirely.
+
+        Returns:
+            Narrow config payload with the updated config.
+        """
+        return await self._request(
+            "PUT",
+            f"/api/v1/experiments/{experiment_uuid}/config",
+            json_data={"config": config},
         )
 
     async def delete(self, experiment_uuid: str) -> Dict[str, Any]:


### PR DESCRIPTION
## For the reviewer

**What the wave-client is:** the small shared library that our experiments (in the browser) and our
setup/analysis notebooks use to talk to the WAVE backend. The experiment webpage uses the JavaScript
version; the notebooks use the Python version.

**What this adds:** the ability to read and write an experiment's **settings** (the "config" — e.g.
number of trials) through that library:
- The experiment webpage can **fetch its settings** when a participant starts it.
- The setup/analysis notebooks can **set or read** an experiment's settings.

**Will it affect anything currently running?** No. This is purely **additive** — new functions plus a
version bump to **1.2.0**. Nothing existing changes, and older experiments that don't use the new
functions keep working exactly as before.

**What merging does:** publishes **version 1.2.0** of the library (to the CDN that experiments load
from, and as a Python package for the notebooks). The experiment-template PR (next) points at this
1.2.0 version, so this needs to be merged **before** that one.

---

## What changed 

- **JavaScript:** `WaveClient.getExperimentConfig(experimentId)` → `GET /api/v1/experiments/{id}/config`
  (reuses the existing retry/error handling). `clientVersion` bumped to `1.2.0`.
- **Python:** `config` field added to the `Experiment` / `ExperimentCreate` / `ExperimentUpdate`
  models; `config` param on `experiments.create()` / `update()`; new `experiments.get_config()` and
  `experiments.set_config()`.
- **Version:** `package.json` and `pyproject.toml` → `1.2.0`.

## Testing
- JS: 52 small tests pass (incl. a new `getExperimentConfig` test; updated a stale `clientVersion`
  assertion).
- Python: 17 small tests pass (incl. new tests for `config` passthrough on create/update and for
  `get_config` / `set_config` hitting the right endpoints/bodies).

## Merge / deploy notes
- This is **PR 2 of 3**. Merge order: **wave-backend → wave-client → experiment-template.**
- Merging to `main` triggers `release.yml`, which **tags `v1.2.0`** and publishes the JS bundle
  (jsDelivr) + the Python wheel. So treat merging this PR as *cutting the release*.
- After merge, verify the release resolved before merging the[ template PR](https://github.com/WAVE-Lab-Williams/experiment-template/pull/16):
  ```bash
  curl -sSI https://cdn.jsdelivr.net/gh/WAVE-Lab-Williams/wave-client@v1.2.0/javascript/dist/wave-client.esm.js   # expect 200
- Depends on the backend ([PR 1](https://github.com/WAVE-Lab-Williams/wave-backend/pull/17)) being deployed so the /config endpoints these methods call exist.